### PR TITLE
Skips over classes that get installed by other modules

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,10 +5,11 @@ class ubuntu_pkgs {
   $pkgs = hiera_array('ubuntu_pkgs', [])
 
   each($ubuntu_pkgs::pkgs) |$mypkg| {
-    package { $mypkg:
-      ensure  => installed,
-      require => Class['apt'],
+    if ! defined(Package[$mypkg]) {
+      package { $mypkg:
+        ensure  => installed,
+        require => Class['apt'],
+      }
     }
   }
-
 }


### PR DESCRIPTION
I got an error when using this module because another module installed the 'unzip' package.  By defending against it, it no longer will error out.
